### PR TITLE
Add proof of ownership for Fastly to openstreetmap.org

### DIFF
--- a/src/openstreetmap.js
+++ b/src/openstreetmap.js
@@ -28,6 +28,9 @@ D(DOMAIN, REGISTRAR, DnsProvider(PROVIDER),
 
   TXT("_mta-sts", "v=STSv1; id=202001291805Z"),
   TXT("_smtp._tls", "v=TLSRPTv1; rua=mailto:postmaster@openstreetmap.org"),
+  
+  // Fastly cert domain ownership confirmation
+  TXT("_globalsign-domain-verification", "ps00GlW1BzY9c2_cwH_pFqRkvzZyaCVZ-3RLssRG6S"),
 
   // Delegate MTA-STS policy for subdomains
 


### PR DESCRIPTION
This is to verify that we own openstreetmap.org so that Fastly can issue SSL certificates for tile.openstreetmap.org as part of https://github.com/openstreetmap/openstreetmap-website/pull/2714 and a potential global rollout.