### PR TITLE
Adds CNAMEs for the Fastly CDN

### DIFF
--- a/src/openstreetmap.js
+++ b/src/openstreetmap.js
@@ -208,6 +208,13 @@ D(DOMAIN, REGISTRAR, DnsProvider(PROVIDER),
   CNAME("a.tile", "tile.geo.openstreetmap.org."),
   CNAME("b.tile", "tile.geo.openstreetmap.org."),
   CNAME("c.tile", "tile.geo.openstreetmap.org."),
+  
+  // Fastly tile CDN testing
+  
+  CNAME("cdn-dev.tile", "osff2.map.fastly.net."),
+  CNAME("a-cdn-dev.tile", "osff2.map.fastly.net."),
+  CNAME("b-cdn-dev.tile", "osff2.map.fastly.net."),
+  CNAME("c-cdn-dev.tile", "osff2.map.fastly.net."),
 
   // Services machine
 


### PR DESCRIPTION
This adds a few CNAMEs in front of tile.openstreetmap.org that point to Fastly's CDN. When this is done I'll update https://github.com/openstreetmap/openstreetmap-website/pull/2714 with the new URLs.