### PR TITLE
Add subdomain for files.osmfoundation.org

### DIFF
--- a/src/osmfoundation.js
+++ b/src/osmfoundation.js
@@ -59,6 +59,7 @@ D(DOMAIN, REGISTRAR, DnsProvider(PROVIDER),
   A("board", RIDLEY_IPV4, TTL("10m")),
   A("dwg", RIDLEY_IPV4, TTL("10m")),
   A("mwg", RIDLEY_IPV4, TTL("10m")),
-  A("operations", RIDLEY_IPV4, TTL("10m"))
+  A("operations", RIDLEY_IPV4, TTL("10m")),
+  A("files", "78.47.246.206", TTL("10m"))
 
 );


### PR DESCRIPTION
Creates subdomain for `files.osmfoundation.org` as requested in https://github.com/openstreetmap/operations/issues/523