### PR TITLE
Remove Gtalk XMPP server entries

### DIFF
--- a/src/osmfoundation.js
+++ b/src/osmfoundation.js
@@ -31,14 +31,6 @@ D(DOMAIN, REGISTRAR, DnsProvider(PROVIDER),
 
   CNAME("uaqn4jv2xaoe", "gv-jun5dginqysxph.dv.googlehosted.com."),
 
-  // XMPP chat servers
-
-  SRV("_xmpp-server._tcp", 5, 0, 5269, "xmpp-server.l.google.com."),
-  SRV("_xmpp-server._tcp", 20, 0, 5269, "xmpp-server1.l.google.com."),
-  SRV("_xmpp-server._tcp", 20, 0, 5269, "xmpp-server2.l.google.com."),
-  SRV("_xmpp-server._tcp", 20, 0, 5269, "xmpp-server3.l.google.com."),
-  SRV("_xmpp-server._tcp", 20, 0, 5269, "xmpp-server4.l.google.com."),
-
   // Aliases for google services
 
   CNAME("login", "ghs.google.com."),


### PR DESCRIPTION
Although I love XMPP, these entries should be removed as Gtalk faded out in 2015, in favour of Hangouts, and [since mid 2017 Google's XMPP is broken](https://workspaceupdates.googleblog.com/2017/03/updates-in-g-suite-to-streamline-hangouts-and-gmail.html):

> Third-party XMPP clients will continue to work with Hangouts for 1-on-1 chats. XMPP federation with third-party services providers will no longer be supported starting June 26.
