### PR TITLE
Remove vestiges of gdns for old tile CDN

### DIFF
--- a/dnsconfig.js
+++ b/dnsconfig.js
@@ -29,11 +29,9 @@ require("src/hosts.js");
 var OPENSTREETMAP = loadTemplate("openstreetmap");
 
 require("include/sshfp.js");
-require("include/tile.js");
-require("include/render.js");
 require("include/nominatim.js");
 
-OPENSTREETMAP("openstreetmap.org", REG_GANDI, SSHFP_RECORDS, TILE_RECORDS, RENDER_RECORDS, NOMINATIM_RECORDS);
+OPENSTREETMAP("openstreetmap.org", REG_GANDI, SSHFP_RECORDS, NOMINATIM_RECORDS);
 OPENSTREETMAP("openstreetmap.com", REG_GANDI);
 OPENSTREETMAP("openstreetmap.net", REG_GANDI);
 OPENSTREETMAP("openstreetmap.ca", REG_GANDI);


### PR DESCRIPTION
In 22b6dfd4 the gdns Make targets for tile and render were removed, but their output was still required in the code. This causes errors on a clean clone.

Tested with `make sshfp gdns && dnscontrol print-ir` and verified there are still CNAME records for tile