### PR TITLE
Switch to HTTP/3 0RTT Fastly stack for tile

### DIFF
--- a/src/openstreetmap.js
+++ b/src/openstreetmap.js
@@ -341,10 +341,10 @@ D(DOMAIN, REGISTRAR, DnsProvider(PROVIDER),
   A("necrosan", NECROSAN_IPV4),
   AAAA("necrosan", NECROSAN_IPV6),
 
-  CNAME("tile", "dualstack.k.sni.global.fastly.net.", TTL("10m")),
-  CNAME("a.tile", "dualstack.k.sni.global.fastly.net.", TTL("10m")),
-  CNAME("b.tile", "dualstack.k.sni.global.fastly.net.", TTL("10m")),
-  CNAME("c.tile", "dualstack.k.sni.global.fastly.net.", TTL("10m")),
+  CNAME("tile", "dualstack.n.sni.global.fastly.net.", TTL("10m")),
+  CNAME("a.tile", "dualstack.n.sni.global.fastly.net.", TTL("10m")),
+  CNAME("b.tile", "dualstack.n.sni.global.fastly.net.", TTL("10m")),
+  CNAME("c.tile", "dualstack.n.sni.global.fastly.net.", TTL("10m")),
   // Fastly DNS based ACME Challenge requirement
   CNAME("_acme-challenge.tile", "bxve5ryiwwv7woiraq.fastly-validations.com.", TTL("10m")),
 


### PR DESCRIPTION
Use the new hostnames as documented in https://docs.fastly.com/en/guides/enabling-http3-for-fastly-services#sending-your-http3-traffic-to-fastly

Fixes https://github.com/openstreetmap/operations/issues/616

This enables 0RTT and HTTP/3.

Tested on top of #15.

To test that this change will not cause problems I overrode the DNS locally with curl and checked the new CNAME works with TLS 1.3 and 1.2. All four requests returned HTTP 200.

```
curl -v -k --tlsv1.3 --tls-max 1.3 --resolve tile.openstreetmap.org:2a04:4e42:d::347 https://tile.openstreetmap.org/cgi-bin/debug
curl -v -k --tlsv1.2 --tls-max 1.2 --resolve tile.openstreetmap.org:2a04:4e42:d::347 https://tile.openstreetmap.org/cgi-bin/debug
curl -v -k --tlsv1.3 --tls-max 1.3 --resolve tile.openstreetmap.org:151.101.213.91 https://tile.openstreetmap.org/cgi-bin/debug
curl -v -k --tlsv1.2 --tls-max 1.2 --resolve tile.openstreetmap.org:151.101.213.91 https://tile.openstreetmap.org/cgi-bin/debug
```