### PR TITLE
Direct render. to new render servers

### DIFF
--- a/src/openstreetmap.js
+++ b/src/openstreetmap.js
@@ -348,6 +348,11 @@ D(DOMAIN, REGISTRAR, DnsProvider(PROVIDER),
   // Fastly DNS based ACME Challenge requirement
   CNAME("_acme-challenge.tile", "bxve5ryiwwv7woiraq.fastly-validations.com.", TTL("10m")),
 
+  A("render", CULEBRE_IPV4),
+  A("render", NIDHOGG_IPV4),
+  AAAA("render", CULEBRE_IPV6),
+  AAAA("render", NIDHOGG_IPV6),
+
   // Services machine
 
   A("ironbelly", IRONBELLY_IPV4),


### PR DESCRIPTION
Removing the remains of gdns broke render.openstreetmap.org, so this
adds it back, pointing at the new European render servers which have
the most capacity.

Long term, a CDN that can handle failover would work better, but
this is a short-term fix to get it working.