### PR TITLE
Update stateofthemap-eu.js

### DIFF
--- a/src/stateofthemap-eu.js
+++ b/src/stateofthemap-eu.js
@@ -27,6 +27,10 @@ D(DOMAIN, REGISTRAR, DnsProvider(PROVIDER),
   // Site hosted on github pages
 
   ALIAS("@", "osmbe.github.io."),
-  CNAME("www", "osmbe.github.io.")
-
+  CNAME("www", "osmbe.github.io."),
+  
+  // Previous editions
+  
+ A("2014", "49.12.5.171")
+  
 );

--- a/src/stateofthemap-eu.js
+++ b/src/stateofthemap-eu.js
@@ -31,6 +31,6 @@ D(DOMAIN, REGISTRAR, DnsProvider(PROVIDER),
   
   // Previous editions
   
- A("2014", "49.12.5.171")
+  A("2014", "49.12.5.171")
   
 );


### PR DESCRIPTION
@woodpeck has contacted us (OSMBE) to put the 2014 version of `stateofthemap.eu` back online.
This apparently runs on a server he owns and SSL certificate for `2014.stateofthemap.eu will be generated when the DNS is updated.