### PR TITLE
Update stateofthemap-eu.js

### DIFF
--- a/src/stateofthemap-eu.js
+++ b/src/stateofthemap-eu.js
@@ -31,6 +31,7 @@ D(DOMAIN, REGISTRAR, DnsProvider(PROVIDER),
   
   // Previous editions
   
-  A("2014", "49.12.5.171")
+  A("2014", "49.12.5.171"),
+  CNAME("2023", "osmbe.github.io.")
   
 );


### PR DESCRIPTION
Add `2023.stateofthemap.eu` sub-domain for 2023 SotM EU website so Poland can re-use `stateofthemap.eu` for this year's edition.

> [!NOTE]
> We use GitHub Pages to host 2023 website. It's still configured for https://stateofthemap.eu/ ; we'll migrate to https://2023.stateofthemap.eu/ as soon as DNS is configured.